### PR TITLE
Tillat tom sisteAndelPerKjede dersom forrige andeler kun inneholder 0-beløp

### DIFF
--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/OppdragBeregnerUtil.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/OppdragBeregnerUtil.kt
@@ -4,6 +4,7 @@ import no.nav.familie.felles.utbetalingsgenerator.domain.AndelData
 import no.nav.familie.felles.utbetalingsgenerator.domain.Behandlingsinformasjon
 import no.nav.familie.felles.utbetalingsgenerator.domain.IdentOgType
 import no.nav.familie.felles.utbetalingsgenerator.domain.YtelseType
+import no.nav.familie.felles.utbetalingsgenerator.domain.uten0beløp
 import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
 
 internal object OppdragBeregnerUtil {
@@ -33,7 +34,7 @@ internal object OppdragBeregnerUtil {
         if (sisteAndelPerKjede.isEmpty() && behandlingsinformasjon.opphørFra != null) {
             error("Kan ikke sende med opphørFra når det ikke finnes noen kjede fra tidligere")
         }
-        if (sisteAndelPerKjede.isEmpty() && forrige.isNotEmpty()) {
+        if (sisteAndelPerKjede.isEmpty() && forrige.uten0beløp().isNotEmpty()) {
             error("Mangler sisteAndelPerKjede når det finnes andeler fra før")
         }
 

--- a/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/OppdragBeregnerUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/OppdragBeregnerUtilTest.kt
@@ -17,7 +17,7 @@ class OppdragBeregnerUtilTest {
 
     private val tomSisteAndelPerKjede = emptyMap<IdentOgType, AndelData>()
     private val sisteAndelPerKjede = mapOf(
-        IdentOgType("", OVERGANGSSTØNAD) to lagAndel(id = "1", periodeId = 1, kildeBehandlingId = "1")
+        IdentOgType("", OVERGANGSSTØNAD) to lagAndel(id = "1", periodeId = 1, kildeBehandlingId = "1"),
     )
 
     @Nested
@@ -125,7 +125,7 @@ class OppdragBeregnerUtilTest {
                 validerAndeler(
                     lagBehandlingsinformasjon(),
                     forrige = listOf(
-                        lagAndel(id = "1", periodeId = 1, forrigePeriodeId = null, kildeBehandlingId = "1")
+                        lagAndel(id = "1", periodeId = 1, forrigePeriodeId = null, kildeBehandlingId = "1"),
                     ),
                     nye = listOf(),
                     sisteAndelPerKjede = tomSisteAndelPerKjede,
@@ -133,6 +133,17 @@ class OppdragBeregnerUtilTest {
             }.hasMessageContaining("Mangler sisteAndelPerKjede når det finnes andeler fra før")
         }
 
+        @Test
+        fun `kan ha tom siste andel per kjede når forrige kun inneholder 0-beløp andeler`() {
+            validerAndeler(
+                lagBehandlingsinformasjon(),
+                forrige = listOf(
+                    lagAndel(id = "1", periodeId = null, forrigePeriodeId = null, kildeBehandlingId = "1", beløp = 0),
+                ),
+                nye = listOf(),
+                sisteAndelPerKjede = tomSisteAndelPerKjede,
+            )
+        }
     }
 
     @Nested


### PR DESCRIPTION
For BA og KS kan det skje at vi har en forrige behandling hvor alle andeler har 0 kr i utbetaling og ingenting er iverksatt fra før. Ved revurdering vil vi da sende med forrige andeler uten at det finnes noen `sisteAndelPerKjede`, hvor alle andeler har beløp = 0. 

Filtrerer derfor bort alle andeler i forrige med 0-beløp i valideringen.