### PR TITLE
Har flyttet inn Utbetalingsoppdrag fra familie-kontrakter hit

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,26 @@ Bibliotek for å generere utbetalingsoppdrag mot økonomi
     * Behandling 2: jan - mars (denne avkorter den forrige, men beholder periodeId)
     * Behandling 3: jan - februar (denne avkorter den forrige, men beholder periodeId, og skal gjenbruke andelen fra behandling 1)
 
+####
+Fagsystem og Ytelsestype er interface som burde implementeres av en enum, eks
+```kotlin
+enum class YtelsestypeEF(
+    override val klassifisering: String,
+    override val satsType: SatsType = SatsType.MND,
+) : Ytelsestype {
+    OVERGANGSSTØNAD("EFOG"),
+    BARNETILSYN("EFBT"),
+    SKOLEPENGER("EFSP", SatsType.ENG),
+}
+
+enum class FagsystemEF(
+    override val kode: String,
+    override val gyldigeSatstyper: Set<Ytelsestype>,
+) : Fagsystem {
+    OVERGANGSSTØNAD("EFOG", setOf(TestYtelsestype.OVERGANGSSTØNAD)),
+}
+```
+
 #### Output
 * [BeregnetUtbetalingsoppdrag](src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/BeregnetUtbetalingsoppdrag.kt)
   * Som inneholder utbetalingsoppdrag og andeler med periodeId/forrigePeriodeId/kildeBehandlingId hvis man trenger å oppdatere andeler i basen

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,6 @@
         <java.version>17</java.version>
         <kotlin.version>1.9.0</kotlin.version>
 
-        <felles-kontrakter.version>3.0_20230808083340_ced4750</felles-kontrakter.version>
-
         <junit-jupiter.version>5.10.0</junit-jupiter.version>
         <assertj.version>3.24.2</assertj.version>
         <cucumber.version>7.13.0</cucumber.version>
@@ -54,9 +52,9 @@
         </dependency>
 
         <dependency>
-            <groupId>no.nav.familie.kontrakter</groupId>
-            <artifactId>felles</artifactId>
-            <version>${felles-kontrakter.version}</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.15.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.15.0</version>
+            <version>2.15.2</version>
         </dependency>
 
         <dependency>

--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/OppdragBeregnerUtil.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/OppdragBeregnerUtil.kt
@@ -3,9 +3,7 @@ package no.nav.familie.felles.utbetalingsgenerator
 import no.nav.familie.felles.utbetalingsgenerator.domain.AndelData
 import no.nav.familie.felles.utbetalingsgenerator.domain.Behandlingsinformasjon
 import no.nav.familie.felles.utbetalingsgenerator.domain.IdentOgType
-import no.nav.familie.felles.utbetalingsgenerator.domain.YtelseType
 import no.nav.familie.felles.utbetalingsgenerator.domain.uten0beløp
-import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
 
 internal object OppdragBeregnerUtil {
 
@@ -47,35 +45,9 @@ internal object OppdragBeregnerUtil {
         behandlingsinformasjon: Behandlingsinformasjon,
     ) {
         val typer = (forrige.map { it.type } + nye.map { it.type })
-        val gyldigeTyper = when (behandlingsinformasjon.ytelse) {
-            Ytelsestype.BARNETRYGD -> BARNETRYGD_GYLDIGE_TYPER
-            Ytelsestype.OVERGANGSSTØNAD -> OVERGANGSSTØNAD_GYLDIGE_TYPER
-            Ytelsestype.BARNETILSYN -> BARNETILSYN_GYLDIGE_TYPER
-            Ytelsestype.SKOLEPENGER -> SKOLEPENGER_GYLDIGE_TYPER
-            Ytelsestype.KONTANTSTØTTE -> KONTANTSTØTTE_GYLDIGE_TYPER
-        }
+        val gyldigeTyper = behandlingsinformasjon.fagsystem.gyldigeSatstyper
         if (!gyldigeTyper.containsAll(typer)) {
             error("Forrige og nye typer inneholder typene=$typer men tillater kun $gyldigeTyper")
         }
     }
-
-    private val BARNETRYGD_GYLDIGE_TYPER = setOf(
-        YtelseType.ORDINÆR_BARNETRYGD,
-        YtelseType.UTVIDET_BARNETRYGD,
-        YtelseType.SMÅBARNSTILLEGG,
-    )
-
-    private val OVERGANGSSTØNAD_GYLDIGE_TYPER = setOf(
-        YtelseType.OVERGANGSSTØNAD,
-    )
-
-    private val BARNETILSYN_GYLDIGE_TYPER = setOf(
-        YtelseType.BARNETILSYN,
-    )
-
-    private val SKOLEPENGER_GYLDIGE_TYPER = setOf(
-        YtelseType.SKOLEPENGER,
-    )
-
-    private val KONTANTSTØTTE_GYLDIGE_TYPER = setOf<YtelseType>() // TODO
 }

--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/Utbetalingsgenerator.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/Utbetalingsgenerator.kt
@@ -9,10 +9,11 @@ import no.nav.familie.felles.utbetalingsgenerator.domain.Behandlingsinformasjon
 import no.nav.familie.felles.utbetalingsgenerator.domain.BeregnetUtbetalingsoppdrag
 import no.nav.familie.felles.utbetalingsgenerator.domain.BeregnetUtbetalingsoppdragLongId
 import no.nav.familie.felles.utbetalingsgenerator.domain.IdentOgType
+import no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag
+import no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag.KodeEndring
+import no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsperiode
+import no.nav.familie.felles.utbetalingsgenerator.domain.groupByIdentOgType
 import no.nav.familie.felles.utbetalingsgenerator.domain.uten0beløp
-import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
-import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag.KodeEndring
-import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
 import org.slf4j.LoggerFactory
 import java.time.YearMonth
 
@@ -83,7 +84,7 @@ class Utbetalingsgenerator {
         val utbetalingsoppdrag = Utbetalingsoppdrag(
             saksbehandlerId = behandlingsinformasjon.saksbehandlerId,
             kodeEndring = kodeEndring(sisteAndelPerKjede),
-            fagSystem = behandlingsinformasjon.ytelse.kode,
+            fagSystem = behandlingsinformasjon.fagsystem.kode,
             saksnummer = behandlingsinformasjon.eksternFagsakId.toString(),
             aktoer = behandlingsinformasjon.personIdent,
             utbetalingsperiode = utbetalingsperioder(behandlingsinformasjon, nyeKjeder),
@@ -218,9 +219,6 @@ class Utbetalingsgenerator {
         }
         return Pair(nyeAndelerMedPeriodeId, gjeldendePeriodeId)
     }
-
-    private fun List<AndelData>.groupByIdentOgType(): Map<IdentOgType, List<AndelData>> =
-        groupBy { IdentOgType(it.personIdent, it.type) }.mapValues { it.value.sortedBy { it.fom } }
 
     private fun lagOpphørsperioder(
         behandlingsinformasjon: Behandlingsinformasjon,

--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/UtbetalingsperiodeMal.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/UtbetalingsperiodeMal.kt
@@ -2,9 +2,8 @@ package no.nav.familie.felles.utbetalingsgenerator
 
 import no.nav.familie.felles.utbetalingsgenerator.domain.AndelData
 import no.nav.familie.felles.utbetalingsgenerator.domain.Behandlingsinformasjon
-import no.nav.familie.kontrakter.felles.oppdrag.Opphør
-import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
-import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
+import no.nav.familie.felles.utbetalingsgenerator.domain.Opphør
+import no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsperiode
 import java.math.BigDecimal
 import java.time.YearMonth
 
@@ -52,11 +51,7 @@ internal data class UtbetalingsperiodeMal(
             vedtakdatoFom = andel.fom.førsteDagIInneværendeMåned(),
             vedtakdatoTom = andel.tom.sisteDagIInneværendeMåned(),
             sats = BigDecimal(andel.beløp),
-            satsType = if (behandlingsinformasjon.ytelse == Ytelsestype.SKOLEPENGER) {
-                Utbetalingsperiode.SatsType.ENG
-            } else {
-                Utbetalingsperiode.SatsType.MND
-            },
+            satsType = andel.type.satsType,
             utbetalesTil = behandlingsinformasjon.utbetalesTil ?: behandlingsinformasjon.personIdent,
             behandlingId = behandlingsinformasjon.eksternBehandlingId,
             utbetalingsgrad = andel.utbetalingsgrad,

--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/AndelData.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/AndelData.kt
@@ -12,7 +12,7 @@ data class AndelData(
     val tom: YearMonth,
     val beløp: Int,
     val personIdent: String,
-    val type: YtelseType,
+    val type: Ytelsestype,
     val periodeId: Long?,
     val forrigePeriodeId: Long?,
     val kildeBehandlingId: String?,
@@ -25,7 +25,7 @@ data class AndelDataLongId(
     val tom: YearMonth,
     val beløp: Int,
     val personIdent: String,
-    val type: YtelseType,
+    val type: Ytelsestype,
     val periodeId: Long?,
     val forrigePeriodeId: Long?,
     val kildeBehandlingId: Long?,
@@ -45,14 +45,12 @@ data class AndelDataLongId(
     )
 }
 
-enum class YtelseType(val klassifisering: String) {
-    ORDINÆR_BARNETRYGD("BATR"),
-    UTVIDET_BARNETRYGD("BATR"),
-    SMÅBARNSTILLEGG("BATRSMA"),
-
-    OVERGANGSSTØNAD("EFOG"),
-    BARNETILSYN("EFBT"),
-    SKOLEPENGER("EFSP"),
+interface Ytelsestype {
+    val satsType: Utbetalingsperiode.SatsType
+    val klassifisering: String
 }
 
 internal fun List<AndelData>.uten0beløp(): List<AndelData> = this.filter { it.beløp != 0 }
+
+internal fun List<AndelData>.groupByIdentOgType(): Map<IdentOgType, List<AndelData>> =
+    groupBy { IdentOgType(it.personIdent, it.type) }.mapValues { it.value.sortedBy { it.fom } }

--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/Behandlingsinformasjon.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/Behandlingsinformasjon.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.felles.utbetalingsgenerator.domain
 
-import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
 import java.time.LocalDate
 import java.time.YearMonth
 
@@ -17,10 +16,15 @@ data class Behandlingsinformasjon(
     val behandlingId: String,
     val eksternBehandlingId: Long,
     val eksternFagsakId: Long,
-    val ytelse: Ytelsestype,
+    val fagsystem: Fagsystem,
     val personIdent: String,
     val vedtaksdato: LocalDate,
     val opphørFra: YearMonth?,
     val utbetalesTil: String? = null,
     val erGOmregning: Boolean = false, // Kan fjernes? Vi sender brev nå
 )
+
+interface Fagsystem {
+    val kode: String
+    val gyldigeSatstyper: Set<Ytelsestype>
+}

--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/BeregnetUtbetalingsoppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/BeregnetUtbetalingsoppdrag.kt
@@ -1,7 +1,5 @@
 package no.nav.familie.felles.utbetalingsgenerator.domain
 
-import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
-
 /**
  * @param andeler er alle andeler med nye periodeId/forrigePeriodeId for å kunne oppdatere lagrede andeler
  */

--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/IdentOgType.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/IdentOgType.kt
@@ -2,5 +2,5 @@ package no.nav.familie.felles.utbetalingsgenerator.domain
 
 data class IdentOgType(
     val ident: String,
-    val type: YtelseType,
+    val type: Ytelsestype,
 )

--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/Utbetalingsoppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/Utbetalingsoppdrag.kt
@@ -1,0 +1,65 @@
+package no.nav.familie.felles.utbetalingsgenerator.domain
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class Utbetalingsoppdrag(
+    val kodeEndring: KodeEndring,
+    val fagSystem: String,
+    val saksnummer: String,
+    val aktoer: String,
+    val saksbehandlerId: String,
+    val avstemmingTidspunkt: LocalDateTime = LocalDateTime.now(),
+    val utbetalingsperiode: List<Utbetalingsperiode>,
+    val gOmregning: Boolean = false,
+) {
+
+    enum class KodeEndring {
+        NY,
+        ENDR,
+        UEND,
+    }
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Utbetalingsperiode(
+    val erEndringPåEksisterendePeriode: Boolean,
+    val opphør: Opphør? = null,
+    val periodeId: Long,
+    val forrigePeriodeId: Long? = null,
+    val datoForVedtak: LocalDate,
+    val klassifisering: String,
+    val vedtakdatoFom: LocalDate,
+    val vedtakdatoTom: LocalDate,
+    val sats: BigDecimal,
+    val satsType: SatsType,
+    val utbetalesTil: String,
+    val behandlingId: Long,
+    val utbetalingsgrad: Int? = null,
+) {
+
+    enum class SatsType {
+        DAG,
+        MND,
+        ENG,
+    }
+}
+
+data class Opphør(val opphørDatoFom: LocalDate)
+
+fun Utbetalingsoppdrag.behandlingsIdForFørsteUtbetalingsperiode(): String {
+    return utbetalingsperiode[0].behandlingId.toString()
+}
+
+val Utbetalingsoppdrag.oppdragId
+    get() = OppdragId(fagSystem, aktoer, behandlingsIdForFørsteUtbetalingsperiode())
+
+data class OppdragId(
+    val fagsystem: String,
+    val personIdent: String,
+    val behandlingsId: String,
+) {
+    override fun toString(): String = "OppdragId(fagsystem=$fagsystem, behandlingsId=$behandlingsId)"
+}

--- a/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/BeståendeAndelerBeregnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/BeståendeAndelerBeregnerTest.kt
@@ -2,7 +2,7 @@ package no.nav.familie.felles.utbetalingsgenerator
 
 import no.nav.familie.felles.utbetalingsgenerator.BeståendeAndelerBeregner.finnBeståendeAndeler
 import no.nav.familie.felles.utbetalingsgenerator.domain.AndelData
-import no.nav.familie.felles.utbetalingsgenerator.domain.YtelseType
+import no.nav.familie.felles.utbetalingsgenerator.domain.Ytelsestype
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.YearMonth
@@ -316,7 +316,7 @@ class BeståendeAndelerBeregnerTest {
         periodeId: Long? = null,
         forrigePeriodeId: Long? = null,
         ident: String = "12",
-        type: YtelseType = YtelseType.ORDINÆR_BARNETRYGD,
+        type: Ytelsestype = TestYtelsestype.ORDINÆR_BARNETRYGD,
     ): AndelData {
         return AndelData(
             id = "0",

--- a/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/OppdragBeregnerUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/OppdragBeregnerUtilTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.felles.utbetalingsgenerator
 
 import no.nav.familie.felles.utbetalingsgenerator.OppdragBeregnerUtil.validerAndeler
+import no.nav.familie.felles.utbetalingsgenerator.TestYtelsestype.ORDINÆR_BARNETRYGD
 import no.nav.familie.felles.utbetalingsgenerator.TestYtelsestype.OVERGANGSSTØNAD
 import no.nav.familie.felles.utbetalingsgenerator.domain.AndelData
 import no.nav.familie.felles.utbetalingsgenerator.domain.Behandlingsinformasjon

--- a/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/OppdragBeregnerUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/OppdragBeregnerUtilTest.kt
@@ -1,12 +1,12 @@
 package no.nav.familie.felles.utbetalingsgenerator
 
 import no.nav.familie.felles.utbetalingsgenerator.OppdragBeregnerUtil.validerAndeler
+import no.nav.familie.felles.utbetalingsgenerator.TestYtelsestype.OVERGANGSSTØNAD
 import no.nav.familie.felles.utbetalingsgenerator.domain.AndelData
 import no.nav.familie.felles.utbetalingsgenerator.domain.Behandlingsinformasjon
+import no.nav.familie.felles.utbetalingsgenerator.domain.Fagsystem
 import no.nav.familie.felles.utbetalingsgenerator.domain.IdentOgType
-import no.nav.familie.felles.utbetalingsgenerator.domain.YtelseType
-import no.nav.familie.felles.utbetalingsgenerator.domain.YtelseType.OVERGANGSSTØNAD
-import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
+import no.nav.familie.felles.utbetalingsgenerator.domain.Ytelsestype
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -236,9 +236,9 @@ class OppdragBeregnerUtilTest {
         fun `skal ikke kunne sende inn en andel av type skolepenger på ytelse overgangsstnad`() {
             assertThatThrownBy {
                 validerAndeler(
-                    lagBehandlingsinformasjon(Ytelsestype.OVERGANGSSTØNAD),
+                    lagBehandlingsinformasjon(TestFagsystem.OVERGANGSSTØNAD),
                     forrige = listOf(),
-                    nye = listOf(lagAndel(ytelseType = YtelseType.SKOLEPENGER)),
+                    nye = listOf(lagAndel(ytelsestype = TestYtelsestype.SKOLEPENGER)),
                     sisteAndelPerKjede = tomSisteAndelPerKjede,
                 )
             }.hasMessageContaining("Forrige og nye typer inneholder typene")
@@ -247,7 +247,7 @@ class OppdragBeregnerUtilTest {
 
     private fun lagAndel(
         id: String = "",
-        ytelseType: YtelseType? = null,
+        ytelsestype: Ytelsestype? = null,
         periodeId: Long? = null,
         forrigePeriodeId: Long? = null,
         kildeBehandlingId: String? = null,
@@ -258,7 +258,7 @@ class OppdragBeregnerUtilTest {
         tom = YearMonth.now(),
         beløp = beløp,
         personIdent = "",
-        type = ytelseType ?: OVERGANGSSTØNAD,
+        type = ytelsestype ?: OVERGANGSSTØNAD,
         periodeId = periodeId,
         forrigePeriodeId = forrigePeriodeId,
         kildeBehandlingId = kildeBehandlingId,
@@ -266,14 +266,14 @@ class OppdragBeregnerUtilTest {
     )
 
     private fun lagBehandlingsinformasjon(
-        ytelse: Ytelsestype = Ytelsestype.OVERGANGSSTØNAD,
+        fagsystem: Fagsystem = TestFagsystem.OVERGANGSSTØNAD,
         opphørFra: YearMonth? = null,
     ) = Behandlingsinformasjon(
         saksbehandlerId = "saksbehandlerId",
         behandlingId = "1",
         eksternBehandlingId = 1L,
         eksternFagsakId = 1L,
-        ytelse = ytelse,
+        fagsystem = fagsystem,
         personIdent = "1",
         vedtaksdato = LocalDate.now(),
         opphørFra = opphørFra,

--- a/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/TestTyper.kt
+++ b/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/TestTyper.kt
@@ -1,0 +1,29 @@
+package no.nav.familie.felles.utbetalingsgenerator
+
+import no.nav.familie.felles.utbetalingsgenerator.domain.Fagsystem
+import no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsperiode.SatsType
+import no.nav.familie.felles.utbetalingsgenerator.domain.Ytelsestype
+
+enum class TestYtelsestype(
+    override val klassifisering: String,
+    override val satsType: SatsType = SatsType.MND,
+) : Ytelsestype {
+    ORDINÆR_BARNETRYGD("BATR"),
+    UTVIDET_BARNETRYGD("BATR"),
+    SMÅBARNSTILLEGG("BATRSMA"),
+
+    OVERGANGSSTØNAD("EFOG"),
+    BARNETILSYN("EFBT"),
+    SKOLEPENGER("EFSP", SatsType.ENG),
+}
+
+enum class TestFagsystem(
+    override val kode: String,
+    override val gyldigeSatstyper: Set<Ytelsestype>,
+) : Fagsystem {
+    OVERGANGSSTØNAD("EFOG", setOf(TestYtelsestype.OVERGANGSSTØNAD)),
+    BARNETILSYN(
+        "BA",
+        setOf(TestYtelsestype.ORDINÆR_BARNETRYGD, TestYtelsestype.UTVIDET_BARNETRYGD, TestYtelsestype.SMÅBARNSTILLEGG),
+    ),
+}

--- a/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/TestTyper.kt
+++ b/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/TestTyper.kt
@@ -22,6 +22,7 @@ enum class TestFagsystem(
     override val gyldigeSatstyper: Set<Ytelsestype>,
 ) : Fagsystem {
     OVERGANGSSTØNAD("EFOG", setOf(TestYtelsestype.OVERGANGSSTØNAD)),
+    SKOLEPENGER("EFSP", setOf(TestYtelsestype.SKOLEPENGER)),
     BARNETILSYN(
         "BA",
         setOf(TestYtelsestype.ORDINÆR_BARNETRYGD, TestYtelsestype.UTVIDET_BARNETRYGD, TestYtelsestype.SMÅBARNSTILLEGG),

--- a/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/cucumber/OppdragSteg.kt
+++ b/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/cucumber/OppdragSteg.kt
@@ -4,6 +4,7 @@ import io.cucumber.datatable.DataTable
 import io.cucumber.java.no.Gitt
 import io.cucumber.java.no.Når
 import io.cucumber.java.no.Så
+import no.nav.familie.felles.utbetalingsgenerator.TestFagsystem
 import no.nav.familie.felles.utbetalingsgenerator.Utbetalingsgenerator
 import no.nav.familie.felles.utbetalingsgenerator.cucumber.ValideringUtil.assertSjekkBehandlingIder
 import no.nav.familie.felles.utbetalingsgenerator.cucumber.domeneparser.Domenebegrep
@@ -24,11 +25,11 @@ import no.nav.familie.felles.utbetalingsgenerator.domain.AndelData
 import no.nav.familie.felles.utbetalingsgenerator.domain.AndelMedPeriodeId
 import no.nav.familie.felles.utbetalingsgenerator.domain.Behandlingsinformasjon
 import no.nav.familie.felles.utbetalingsgenerator.domain.BeregnetUtbetalingsoppdrag
+import no.nav.familie.felles.utbetalingsgenerator.domain.Fagsystem
 import no.nav.familie.felles.utbetalingsgenerator.domain.IdentOgType
+import no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag
+import no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsperiode
 import no.nav.familie.felles.utbetalingsgenerator.domain.uten0beløp
-import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
-import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
-import no.nav.familie.kontrakter.felles.tilbakekreving.Ytelsestype
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowable
 import org.slf4j.LoggerFactory
@@ -130,7 +131,7 @@ class OppdragSteg {
             behandlingsinformasjon[behandlingId] = lagBehandlingsinformasjon(
                 behandlingId = behandlingId,
                 opphørFra = parseValgfriÅrMåned(DomenebegrepBehandlingsinformasjon.OPPHØR_FRA, rad),
-                ytelse = parseValgfriEnum<Ytelsestype>(DomenebegrepBehandlingsinformasjon.YTELSE, rad),
+                fagsystem = parseValgfriEnum<TestFagsystem>(DomenebegrepBehandlingsinformasjon.FAGSYSTEM, rad),
             )
         }
     }
@@ -146,13 +147,13 @@ class OppdragSteg {
     private fun lagBehandlingsinformasjon(
         behandlingId: Long,
         opphørFra: YearMonth? = null,
-        ytelse: Ytelsestype? = null,
+        fagsystem: Fagsystem? = null,
     ) = Behandlingsinformasjon(
         saksbehandlerId = "saksbehandlerId",
         behandlingId = behandlingId.toString(),
         eksternBehandlingId = behandlingId,
         eksternFagsakId = 1L,
-        ytelse = ytelse ?: Ytelsestype.BARNETRYGD,
+        fagsystem = fagsystem ?: TestFagsystem.BARNETILSYN,
         personIdent = "1",
         vedtaksdato = LocalDate.now(),
         opphørFra = opphørFra,

--- a/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/cucumber/domeneparser/OppdragParser.kt
+++ b/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/cucumber/domeneparser/OppdragParser.kt
@@ -1,11 +1,11 @@
 package no.nav.familie.felles.utbetalingsgenerator.cucumber.domeneparser
 
 import io.cucumber.datatable.DataTable
+import no.nav.familie.felles.utbetalingsgenerator.TestYtelsestype
 import no.nav.familie.felles.utbetalingsgenerator.cucumber.domeneparser.DomeneparserUtil.groupByBehandlingId
 import no.nav.familie.felles.utbetalingsgenerator.domain.AndelData
-import no.nav.familie.felles.utbetalingsgenerator.domain.YtelseType
-import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
-import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
+import no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag
+import no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsperiode
 import org.assertj.core.api.Assertions.assertThat
 import java.time.LocalDate
 
@@ -37,7 +37,7 @@ object OppdragParser {
         rad: Map<String, String>,
         andelId: Long,
     ): AndelData {
-        val ytelseType = parseValgfriEnum(DomenebegrepAndeler.YTELSE_TYPE, rad) ?: YtelseType.ORDINÆR_BARNETRYGD
+        val ytelseType = parseValgfriEnum(DomenebegrepAndeler.YTELSE_TYPE, rad) ?: TestYtelsestype.ORDINÆR_BARNETRYGD
         return AndelData(
             id = andelId.toString(),
             fom = parseÅrMåned(Domenebegrep.FRA_DATO, rad),
@@ -72,8 +72,8 @@ object OppdragParser {
             periodeId = parseLong(DomenebegrepUtbetalingsoppdrag.PERIODE_ID, it),
             forrigePeriodeId = parseValgfriLong(DomenebegrepUtbetalingsoppdrag.FORRIGE_PERIODE_ID, it),
             sats = parseInt(DomenebegrepUtbetalingsoppdrag.BELØP, it),
-            ytelse = parseValgfriEnum<YtelseType>(DomenebegrepUtbetalingsoppdrag.YTELSE_TYPE, it)
-                ?: YtelseType.ORDINÆR_BARNETRYGD,
+            ytelse = parseValgfriEnum<TestYtelsestype>(DomenebegrepUtbetalingsoppdrag.YTELSE_TYPE, it)
+                ?: TestYtelsestype.ORDINÆR_BARNETRYGD,
             fom = parseÅrMåned(Domenebegrep.FRA_DATO, it).atDay(1),
             tom = parseÅrMåned(Domenebegrep.TIL_DATO, it).atEndOfMonth(),
             opphør = parseValgfriÅrMåned(DomenebegrepUtbetalingsoppdrag.OPPHØRSDATO, it)?.atDay(1),
@@ -98,7 +98,7 @@ object OppdragParser {
 
 enum class DomenebegrepBehandlingsinformasjon(override val nøkkel: String) : Domenenøkkel {
     OPPHØR_FRA("Opphør fra"),
-    YTELSE("Ytelse"),
+    FAGSYSTEM("Fagsystem"),
 }
 
 enum class DomenebegrepAndeler(override val nøkkel: String) : Domenenøkkel {
@@ -131,7 +131,7 @@ data class ForventetUtbetalingsperiode(
     val periodeId: Long,
     val forrigePeriodeId: Long?,
     val sats: Int,
-    val ytelse: YtelseType,
+    val ytelse: TestYtelsestype,
     val fom: LocalDate,
     val tom: LocalDate,
     val opphør: LocalDate?,

--- a/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/AndelDataTest.kt
+++ b/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/AndelDataTest.kt
@@ -1,0 +1,41 @@
+package no.nav.familie.felles.utbetalingsgenerator.domain
+
+import no.nav.familie.felles.utbetalingsgenerator.TestYtelsestype
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+import java.util.UUID
+
+class AndelDataTest {
+
+    @Test
+    fun `groupByIdentOgType skal gruppere ulike stønadstyper`() {
+        val andel1 = andelData("1", TestYtelsestype.OVERGANGSSTØNAD)
+        val andel2 = andelData("1", TestYtelsestype.OVERGANGSSTØNAD)
+        val andel3 = andelData("2", TestYtelsestype.OVERGANGSSTØNAD)
+        val andel4 = andelData("1", TestYtelsestype.SKOLEPENGER)
+
+        val gruppertAndeler = listOf(andel1, andel2, andel3, andel4).groupByIdentOgType()
+
+        assertThat(gruppertAndeler.keys).hasSize(3)
+        assertThat(gruppertAndeler[IdentOgType("1", TestYtelsestype.OVERGANGSSTØNAD)])
+            .containsExactly(andel1, andel2)
+        assertThat(gruppertAndeler[IdentOgType("2", TestYtelsestype.OVERGANGSSTØNAD)])
+            .containsExactly(andel3)
+        assertThat(gruppertAndeler[IdentOgType("1", TestYtelsestype.SKOLEPENGER)])
+            .containsExactly(andel4)
+    }
+
+    private fun andelData(ident: String, type: TestYtelsestype) = AndelData(
+        id = UUID.randomUUID().toString(),
+        fom = YearMonth.now(),
+        tom = YearMonth.now(),
+        beløp = 1,
+        personIdent = ident,
+        type = type,
+        periodeId = null,
+        forrigePeriodeId = null,
+        kildeBehandlingId = null,
+        utbetalingsgrad = null,
+    )
+}

--- a/src/test/resources/cucumber/oppdrag/oppdrag.feature
+++ b/src/test/resources/cucumber/oppdrag/oppdrag.feature
@@ -173,7 +173,7 @@ Egenskap: Vedtak for førstegangsbehandling
   Scenario: Skolepenger skal bruke engangsutbetaling
 
     Gitt følgende behandlingsinformasjon
-      | BehandlingId | Ytelse      |
+      | BehandlingId | Fagsystem   |
       | 1            | SKOLEPENGER |
 
     Gitt følgende tilkjente ytelser


### PR DESCRIPTION
Endret Fagsystem og Ytelsestype til interface for å kunne tas i bruk av eks tilleggsstønader og

#### Hvorfor? 
* Kontrakter fordi tilleggsstønader ikke ønsker direkt kobling till familie-kontrakter, og disse klassene hører fint hjemme her
* For å ikke blande inn for mye koblet til fagsystemet inn her, men att eksponere interface som gjør logikken ryddigere