### PR TITLE
Utvidet `Behandlingsinformasjon` med feltet `opphørKjederFraFørsteUtbetaling`

### DIFF
--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/OppdragBeregnerUtil.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/OppdragBeregnerUtil.kt
@@ -31,6 +31,9 @@ internal object OppdragBeregnerUtil {
             forrige.find { it.fom < opphørFra }
                 ?.let { error("Ugyldig opphørFra=$opphørFra som er etter andel=${it.id} sitt fom=${it.fom}") }
         }
+        if (behandlingsinformasjon.opphørKjederFraFørsteUtbetaling && behandlingsinformasjon.opphørFra != null) {
+            error("Kan ikke sette opphørKjederFraFørsteUtbetaling til true samtidig som opphørFra er satt")
+        }
         if (sisteAndelPerKjede.isEmpty() && behandlingsinformasjon.opphørFra != null) {
             error("Kan ikke sende med opphørFra når det ikke finnes noen kjede fra tidligere")
         }

--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/Utbetalingsgenerator.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/Utbetalingsgenerator.kt
@@ -138,6 +138,9 @@ class Utbetalingsgenerator {
         if (sisteAndel == null) {
             return null
         }
+        if (behandlingsinformasjon.opphørKjederFraFørsteUtbetaling) {
+            return nyeAndeler.uten0beløp().minOf { it.fom }
+        }
         return behandlingsinformasjon.opphørFra ?: finnOpphørsdatoPga0Beløp(forrigeAndeler, nyeAndeler)
     }
 

--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/Behandlingsinformasjon.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/Behandlingsinformasjon.kt
@@ -23,4 +23,5 @@ data class Behandlingsinformasjon(
     val opphørFra: YearMonth?,
     val utbetalesTil: String? = null,
     val erGOmregning: Boolean = false, // Kan fjernes? Vi sender brev nå
+    val opphørKjederFraFørsteUtbetaling: Boolean = false,
 )

--- a/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/cucumber/OppdragSteg.kt
+++ b/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/cucumber/OppdragSteg.kt
@@ -17,6 +17,7 @@ import no.nav.familie.felles.utbetalingsgenerator.cucumber.domeneparser.OppdragP
 import no.nav.familie.felles.utbetalingsgenerator.cucumber.domeneparser.OppdragParser.mapAndeler
 import no.nav.familie.felles.utbetalingsgenerator.cucumber.domeneparser.parseLong
 import no.nav.familie.felles.utbetalingsgenerator.cucumber.domeneparser.parseString
+import no.nav.familie.felles.utbetalingsgenerator.cucumber.domeneparser.parseValgfriBoolean
 import no.nav.familie.felles.utbetalingsgenerator.cucumber.domeneparser.parseValgfriEnum
 import no.nav.familie.felles.utbetalingsgenerator.cucumber.domeneparser.parseValgfriLong
 import no.nav.familie.felles.utbetalingsgenerator.cucumber.domeneparser.parseValgfriÅrMåned
@@ -131,6 +132,7 @@ class OppdragSteg {
                 behandlingId = behandlingId,
                 opphørFra = parseValgfriÅrMåned(DomenebegrepBehandlingsinformasjon.OPPHØR_FRA, rad),
                 ytelse = parseValgfriEnum<Ytelsestype>(DomenebegrepBehandlingsinformasjon.YTELSE, rad),
+                opphørKjederFraFørsteUtbetaling = parseValgfriBoolean(DomenebegrepBehandlingsinformasjon.OPPHØR_KJEDER_FRA_FØRSTE_UTBETALING, rad) ?: false,
             )
         }
     }
@@ -147,6 +149,7 @@ class OppdragSteg {
         behandlingId: Long,
         opphørFra: YearMonth? = null,
         ytelse: Ytelsestype? = null,
+        opphørKjederFraFørsteUtbetaling: Boolean = false,
     ) = Behandlingsinformasjon(
         saksbehandlerId = "saksbehandlerId",
         behandlingId = behandlingId.toString(),
@@ -157,6 +160,7 @@ class OppdragSteg {
         vedtaksdato = LocalDate.now(),
         opphørFra = opphørFra,
         utbetalesTil = null,
+        opphørKjederFraFørsteUtbetaling = opphørKjederFraFørsteUtbetaling,
     )
 
     private fun beregnUtbetalingsoppdrag(

--- a/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/cucumber/domeneparser/OppdragParser.kt
+++ b/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/cucumber/domeneparser/OppdragParser.kt
@@ -99,6 +99,7 @@ object OppdragParser {
 enum class DomenebegrepBehandlingsinformasjon(override val nøkkel: String) : Domenenøkkel {
     OPPHØR_FRA("Opphør fra"),
     YTELSE("Ytelse"),
+    OPPHØR_KJEDER_FRA_FØRSTE_UTBETALING("Opphør kjeder fra første utbetaling")
 }
 
 enum class DomenebegrepAndeler(override val nøkkel: String) : Domenenøkkel {

--- a/src/test/resources/cucumber/oppdrag/opphørKjederFraFørsteUtbetaling.feature
+++ b/src/test/resources/cucumber/oppdrag/opphørKjederFraFørsteUtbetaling.feature
@@ -1,0 +1,88 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Sender med opphørKjederFraFørsteUtbetaling
+
+
+  Scenario: Skal opphøre alle kjeder fra første utbetaling dersom opphørKjederFraFørsteUtbetaling er satt til true
+
+    Gitt følgende behandlingsinformasjon
+      | BehandlingId | Opphør kjeder fra første utbetaling |
+      | 2            | Ja                                  |
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp | Ident |
+      | 1            | 03.2021  | 03.2021  | 700   | 1     |
+      | 1            | 04.2021  | 08.2023  | 800   | 1     |
+      | 1            | 06.2021  | 08.2022  | 700   | 2     |
+      | 1            | 09.2022  | 08.2023  | 800   | 2     |
+
+      | 2            | 03.2021  | 03.2021  | 750   | 1     |
+      | 2            | 04.2021  | 08.2023  | 850   | 1     |
+      | 2            | 06.2021  | 08.2022  | 750   | 2     |
+      | 2            | 09.2022  | 08.2023  | 850   | 2     |
+
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
+      | 1            | 04.2021  | 08.2023  |             | 800   | NY           | Nei        | 1          | 0                  |
+      | 1            | 06.2021  | 08.2022  |             | 700   | NY           | Nei        | 2          |                    |
+      | 1            | 09.2022  | 08.2023  |             | 800   | NY           | Nei        | 3          | 2                  |
+
+
+      | 2            | 04.2021  | 08.2023  | 03.2021     | 800   | ENDR         | Ja         | 1          | 0                  |
+      | 2            | 09.2022  | 08.2023  | 06.2021     | 800   | ENDR         | Ja         | 3          | 2                  |
+      | 2            | 03.2021  | 03.2021  |             | 750   | ENDR         | Nei        | 4          | 1                  |
+      | 2            | 04.2021  | 08.2023  |             | 850   | ENDR         | Nei        | 5          | 4                  |
+      | 2            | 06.2021  | 08.2022  |             | 750   | ENDR         | Nei        | 6          | 3                  |
+      | 2            | 09.2022  | 08.2023  |             | 850   | ENDR         | Nei        | 7          | 6                  |
+
+  Scenario: Skal opphøre alle kjeder fra første utbetaling dersom opphørKjederFraFørsteUtbetaling er satt til true og første andel er 0-utbetaling
+
+    Gitt følgende behandlingsinformasjon
+      | BehandlingId | Opphør kjeder fra første utbetaling |
+      | 2            | Ja                                  |
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp | Ident |
+      | 1            | 03.2021  | 03.2021  | 0     | 1     |
+      | 1            | 04.2021  | 08.2023  | 800   | 1     |
+      | 1            | 06.2021  | 08.2022  | 0     | 2     |
+      | 1            | 09.2022  | 08.2023  | 800   | 2     |
+
+      | 2            | 03.2021  | 03.2021  | 0     | 1     |
+      | 2            | 04.2021  | 08.2023  | 850   | 1     |
+      | 2            | 06.2021  | 08.2022  | 0     | 2     |
+      | 2            | 09.2022  | 08.2023  | 850   | 2     |
+
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 04.2021  | 08.2023  |             | 800   | NY           | Nei        | 0          |                    |
+      | 1            | 09.2022  | 08.2023  |             | 800   | NY           | Nei        | 1          |                    |
+
+
+      | 2            | 04.2021  | 08.2023  | 04.2021     | 800   | ENDR         | Ja         | 0          |                    |
+      | 2            | 09.2022  | 08.2023  | 09.2022     | 800   | ENDR         | Ja         | 1          |                    |
+      | 2            | 04.2021  | 08.2023  |             | 850   | ENDR         | Nei        | 2          | 0                  |
+      | 2            | 09.2022  | 08.2023  |             | 850   | ENDR         | Nei        | 3          | 1                  |
+
+
+  Scenario: Kan ikke sette opphørKjederFraFørsteUtbetaling til true og samtidig sende med en opphørFra dato
+
+    Gitt følgende behandlingsinformasjon
+      | BehandlingId | Opphør kjeder fra første utbetaling | Opphør fra |
+      | 1            | Ja                                  | 03.2021    |
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp |
+      | 1            | 03.2021  | 03.2021  | 700   |
+
+    Når beregner utbetalingsoppdrag kjøres kastes exception
+      | Melding                                                                                |
+      | Kan ikke sette opphørKjederFraFørsteUtbetaling til true samtidig som opphørFra er satt |

--- a/src/test/resources/cucumber/oppdrag/opphørsdato.feature
+++ b/src/test/resources/cucumber/oppdrag/opphørsdato.feature
@@ -76,38 +76,3 @@ Egenskap: Sender med opphørFra
       | Melding            |
       | som er etter andel |
 
-
-  Scenario: Revurderer en tidligere behandling, samtidig som man opphører lengre bak i tiden (eks med simulering)
-
-    Gitt følgende behandlingsinformasjon
-      | BehandlingId | Opphør fra |
-      | 2            | 05.2022    |
-
-    Gitt følgende tilkjente ytelser
-      | BehandlingId | Fra dato | Til dato | Beløp | Ident |
-      | 1            | 05.2022  | 02.2023  | 1676  | 1     |
-      | 1            | 03.2023  | 06.2023  | 1723  | 1     |
-      | 1            | 07.2023  | 03.2026  | 1766  | 1     |
-      | 1            | 04.2026  | 03.2038  | 1310  | 1     |
-
-      | 2            | 05.2022  | 02.2023  | 1676  | 1     |
-      | 2            | 03.2023  | 06.2023  | 1723  | 1     |
-      | 2            | 07.2023  | 08.2023  | 1766  | 1     |
-      | 2            | 09.2023  | 03.2026  | 883   | 1     |
-      | 2            | 04.2026  | 03.2038  | 655   | 1     |
-
-    Når beregner utbetalingsoppdrag
-
-    Så forvent følgende utbetalingsoppdrag
-      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
-      | 1            | 05.2022  | 02.2023  |             | 1676  | NY           | Nei        | 0          |                    |
-      | 1            | 03.2023  | 06.2023  |             | 1723  | NY           | Nei        | 1          | 0                  |
-      | 1            | 07.2023  | 03.2026  |             | 1766  | NY           | Nei        | 2          | 1                  |
-      | 1            | 04.2026  | 03.2038  |             | 1310  | NY           | Nei        | 3          | 2                  |
-
-      | 2            | 04.2026  | 03.2038  | 05.2022     | 1310  | ENDR         | Ja         | 3          | 2                  |
-      | 2            | 05.2022  | 02.2023  |             | 1676  | ENDR         | Nei        | 4          | 3                  |
-      | 2            | 03.2023  | 06.2023  |             | 1723  | ENDR         | Nei        | 5          | 4                  |
-      | 2            | 07.2023  | 08.2023  |             | 1766  | ENDR         | Nei        | 6          | 5                  |
-      | 2            | 09.2023  | 03.2026  |             | 883   | ENDR         | Nei        | 7          | 6                  |
-      | 2            | 04.2026  | 03.2038  |             | 655   | ENDR         | Nei        | 8          | 7                  |

--- a/src/test/resources/cucumber/oppdrag/opphørsdato.feature
+++ b/src/test/resources/cucumber/oppdrag/opphørsdato.feature
@@ -58,8 +58,8 @@ Egenskap: Sender med opphørFra
       | 1            | 03.2021  | 03.2021  | 700   |
 
     Når beregner utbetalingsoppdrag kjøres kastes exception
-      | Melding                               |
-      | Må ha siste andel for å kunne opphøre |
+      | Melding                                                                   |
+      | Kan ikke sende med opphørFra når det ikke finnes noen kjede fra tidligere |
 
   Scenario: Kan ikke sende med opphørFra etter første fom på forrige andeler
 
@@ -76,3 +76,38 @@ Egenskap: Sender med opphørFra
       | Melding            |
       | som er etter andel |
 
+
+  Scenario: Revurderer en tidligere behandling, samtidig som man opphører lengre bak i tiden (eks med simulering)
+
+    Gitt følgende behandlingsinformasjon
+      | BehandlingId | Opphør fra |
+      | 2            | 05.2022    |
+
+    Gitt følgende tilkjente ytelser
+      | BehandlingId | Fra dato | Til dato | Beløp | Ident |
+      | 1            | 05.2022  | 02.2023  | 1676  | 1     |
+      | 1            | 03.2023  | 06.2023  | 1723  | 1     |
+      | 1            | 07.2023  | 03.2026  | 1766  | 1     |
+      | 1            | 04.2026  | 03.2038  | 1310  | 1     |
+
+      | 2            | 05.2022  | 02.2023  | 1676  | 1     |
+      | 2            | 03.2023  | 06.2023  | 1723  | 1     |
+      | 2            | 07.2023  | 08.2023  | 1766  | 1     |
+      | 2            | 09.2023  | 03.2026  | 883   | 1     |
+      | 2            | 04.2026  | 03.2038  | 655   | 1     |
+
+    Når beregner utbetalingsoppdrag
+
+    Så forvent følgende utbetalingsoppdrag
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
+      | 1            | 05.2022  | 02.2023  |             | 1676  | NY           | Nei        | 0          |                    |
+      | 1            | 03.2023  | 06.2023  |             | 1723  | NY           | Nei        | 1          | 0                  |
+      | 1            | 07.2023  | 03.2026  |             | 1766  | NY           | Nei        | 2          | 1                  |
+      | 1            | 04.2026  | 03.2038  |             | 1310  | NY           | Nei        | 3          | 2                  |
+
+      | 2            | 04.2026  | 03.2038  | 05.2022     | 1310  | ENDR         | Ja         | 3          | 2                  |
+      | 2            | 05.2022  | 02.2023  |             | 1676  | ENDR         | Nei        | 4          | 3                  |
+      | 2            | 03.2023  | 06.2023  |             | 1723  | ENDR         | Nei        | 5          | 4                  |
+      | 2            | 07.2023  | 08.2023  |             | 1766  | ENDR         | Nei        | 6          | 5                  |
+      | 2            | 09.2023  | 03.2026  |             | 883   | ENDR         | Nei        | 7          | 6                  |
+      | 2            | 04.2026  | 03.2038  |             | 655   | ENDR         | Nei        | 8          | 7                  |


### PR DESCRIPTION
I ba-sak er vi avhengig av å kunne opphøre kjeder individuelt med egen opphørsdato i forbindelse med simulering. Dette fordi vi ønsker å unngå å få simuleringsresultater fra før ba-sak gir utbetaling.

Ved bruk av `opphørFra` feltet risikerer vi å opphøre fra før første utbetaling fra ba-sak og dermed få med data fra infotrygd i simuleringsresultat. Dette gjelder i saker der vi har andeler som overlapper med andelene fra infotrygd og vi i ba-sak har avslått periodene eller endret utbetaling til 0. Når vi da opphører fra start og ikke fra første utbetaling får vi simuleringsresultater fra infotrygd før ba-sak utbetaler noe.

Har derfor lagt til feltet `opphørKjederFraFørsteUtbetaling` og logikk for å bestemme individuell opphørsdato for kjeder.