### PR TITLE
Finner opphørsdato basert på forrige andeler fremfor nye

### DIFF
--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/Utbetalingsgenerator.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/Utbetalingsgenerator.kt
@@ -140,7 +140,7 @@ class Utbetalingsgenerator {
             return null
         }
         if (behandlingsinformasjon.opphørKjederFraFørsteUtbetaling) {
-            return nyeAndeler.uten0beløp().minOf { it.fom }
+            return forrigeAndeler.uten0beløp().minOf { it.fom }
         }
         return behandlingsinformasjon.opphørFra ?: finnOpphørsdatoPga0Beløp(forrigeAndeler, nyeAndeler)
     }


### PR DESCRIPTION
Vi er nødt til å se på de forrige andelene for å finne ut hva som skal være opphørsdato når `opphørKjederFraFørsteUtbetaling` er satt til `true`. Det kan fort skje at nye andeler har utbetalinger etter utbetalingene i forrige behandling og da blir opphørsdatoen feil. Kaster også feil dersom nye kun har 0-utbetalinger.