### PR TITLE
Sørger for at opphørsdato blir satt til null dersom forrige andeler er tom eller bare har 0-utbetalinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/Utbetalingsgenerator.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/Utbetalingsgenerator.kt
@@ -140,7 +140,7 @@ class Utbetalingsgenerator {
             return null
         }
         if (behandlingsinformasjon.opphørKjederFraFørsteUtbetaling) {
-            return forrigeAndeler.uten0beløp().minOf { it.fom }
+            return forrigeAndeler.uten0beløp().minOfOrNull { it.fom }
         }
         return behandlingsinformasjon.opphørFra ?: finnOpphørsdatoPga0Beløp(forrigeAndeler, nyeAndeler)
     }


### PR DESCRIPTION
Vi får en `NoSuchElementException` i metoden `finnOpphørsdato` fordi `forrigeAndeler` enten er tom eller kun har 0-utbetalinger. 

Dette kan skje dersom forrige behandling var et opphør og det i en tidligere behandling har blitt sendt noe til økonomi. I disse tilfellene ønsker vi å sette opphørsdato til `null` slik at det er de nye andelene som får diktere når vi får simulering fra. Akkurat som for førstegangsbehandlinger.