### PR TITLE
Fix: Deterministisk generering av nye kjedeelementer

### DIFF
--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/Utbetalingsgenerator.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/Utbetalingsgenerator.kt
@@ -106,7 +106,7 @@ class Utbetalingsgenerator {
     ): List<ResultatForKjede> {
         val alleIdentOgTyper = nyeKjeder.keys + forrigeKjeder.keys
         var sistePeriodeId = sisteAndelPerKjede.values.mapNotNull { it.periodeId }.maxOrNull() ?: -1
-        return alleIdentOgTyper.map { identOgType ->
+        return alleIdentOgTyper.sorted().map { identOgType ->
             val forrigeAndeler = forrigeKjeder[identOgType] ?: emptyList()
             val nyeAndeler = nyeKjeder[identOgType] ?: emptyList()
             val sisteAndel = sisteAndelPerKjede[identOgType]

--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/Utbetalingsgenerator.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/Utbetalingsgenerator.kt
@@ -158,8 +158,10 @@ class Utbetalingsgenerator {
         val forrigeFørsteAndel = forrigeAndeler.firstOrNull()
         val nyFørsteAndel = nyeAndeler.firstOrNull()
         if (
-            forrigeFørsteAndel != null && nyFørsteAndel != null &&
-            nyFørsteAndel.beløp == 0 && nyFørsteAndel.fom < forrigeFørsteAndel.fom
+            forrigeFørsteAndel != null &&
+            nyFørsteAndel != null &&
+            nyFørsteAndel.beløp == 0 &&
+            nyFørsteAndel.fom < forrigeFørsteAndel.fom
         ) {
             return nyFørsteAndel.fom
         }

--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/IdentOgType.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/IdentOgType.kt
@@ -3,4 +3,8 @@ package no.nav.familie.felles.utbetalingsgenerator.domain
 data class IdentOgType(
     val ident: String,
     val type: Ytelsestype,
-)
+) : Comparable<IdentOgType> {
+    override fun compareTo(other: IdentOgType): Int {
+        return (type.klassifisering + ident).compareTo(other.type.klassifisering  + other.ident)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/IdentOgType.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/IdentOgType.kt
@@ -4,7 +4,5 @@ data class IdentOgType(
     val ident: String,
     val type: Ytelsestype,
 ) : Comparable<IdentOgType> {
-    override fun compareTo(other: IdentOgType): Int {
-        return (type.klassifisering + ident).compareTo(other.type.klassifisering  + other.ident)
-    }
+    override fun compareTo(other: IdentOgType): Int = (type.klassifisering + ident).compareTo((other.type.klassifisering + other.ident))
 }

--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/Utbetalingsoppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/Utbetalingsoppdrag.kt
@@ -45,11 +45,11 @@ data class Utbetalingsperiode(
     }
 }
 
-data class Opphør(val opphørDatoFom: LocalDate)
+data class Opphør(
+    val opphørDatoFom: LocalDate,
+)
 
-fun Utbetalingsoppdrag.behandlingsIdForFørsteUtbetalingsperiode(): String {
-    return utbetalingsperiode[0].behandlingId.toString()
-}
+fun Utbetalingsoppdrag.behandlingsIdForFørsteUtbetalingsperiode(): String = utbetalingsperiode[0].behandlingId.toString()
 
 val Utbetalingsoppdrag.oppdragId
     get() = OppdragId(fagSystem, aktoer, behandlingsIdForFørsteUtbetalingsperiode())

--- a/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/TestTyper.kt
+++ b/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/TestTyper.kt
@@ -9,7 +9,7 @@ enum class TestYtelsestype(
     override val satsType: SatsType = SatsType.MND,
 ) : Ytelsestype {
     ORDINÆR_BARNETRYGD("BATR"),
-    UTVIDET_BARNETRYGD("BATR"),
+    UTVIDET_BARNETRYGD("BAUTV-OP"),
     SMÅBARNSTILLEGG("BATRSMA"),
 
     OVERGANGSSTØNAD("EFOG"),

--- a/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/cucumber/OppdragSteg.kt
+++ b/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/cucumber/OppdragSteg.kt
@@ -56,7 +56,8 @@ class OppdragSteg {
         genererBehandlingsinformasjonForDeSomMangler(dataTable)
         andelerPerBehandlingId = mapAndeler(dataTable)
         if (
-            andelerPerBehandlingId.flatMap { it.value }
+            andelerPerBehandlingId
+                .flatMap { it.value }
                 .any { it.kildeBehandlingId != null || it.periodeId != null || it.forrigePeriodeId != null }
         ) {
             error("Kildebehandling/periodeId/forrigePeriodeId skal ikke settes på input, denne settes fra utbetalingsgeneratorn")
@@ -189,14 +190,14 @@ class OppdragSteg {
      * Når vi henter forrige offset for en kjede så må vi hente max periodeId, men den første hendelsen av den typen
      * Dette då vi i noen tilfeller opphører en peride, som beholder den samme periodeId'n
      */
-    private fun gjeldendeForrigeOffsetForKjede(forrigeKjeder: List<Pair<Long, List<AndelData>>>): Map<IdentOgType, AndelData> {
-        return forrigeKjeder.flatMap { it.second }
+    private fun gjeldendeForrigeOffsetForKjede(forrigeKjeder: List<Pair<Long, List<AndelData>>>): Map<IdentOgType, AndelData> =
+        forrigeKjeder
+            .flatMap { it.second }
             .uten0beløp()
             .groupBy { IdentOgType(it.personIdent, it.type) }
             .mapValues {
                 it.value.sortedWith(compareByDescending<AndelData> { it.periodeId!! }.thenBy { it.id }).first()
             }
-    }
 
     private fun oppdaterAndelerMedPeriodeId(
         beregnUtbetalingsoppdrag: BeregnetUtbetalingsoppdrag,

--- a/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/IdentOgTypeTest.kt
+++ b/src/test/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/IdentOgTypeTest.kt
@@ -1,0 +1,31 @@
+package no.nav.familie.felles.utbetalingsgenerator.domain
+
+import no.nav.familie.felles.utbetalingsgenerator.TestYtelsestype
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class IdentOgTypeTest {
+    @Test
+    fun `skal sorteres etter klassifisering og ident`() {
+        // Arrange
+        val identOgTypeListe =
+            listOf(
+                IdentOgType("12345678912", TestYtelsestype.ORDINÆR_BARNETRYGD),
+                IdentOgType("12345678910", TestYtelsestype.UTVIDET_BARNETRYGD),
+                IdentOgType("12345678910", TestYtelsestype.ORDINÆR_BARNETRYGD),
+                IdentOgType("12345678911", TestYtelsestype.ORDINÆR_BARNETRYGD),
+            )
+        val forventetSortertListe =
+            listOf(
+                IdentOgType("12345678910", TestYtelsestype.ORDINÆR_BARNETRYGD),
+                IdentOgType("12345678911", TestYtelsestype.ORDINÆR_BARNETRYGD),
+                IdentOgType("12345678912", TestYtelsestype.ORDINÆR_BARNETRYGD),
+                IdentOgType("12345678910", TestYtelsestype.UTVIDET_BARNETRYGD),
+            )
+        // Act
+        val sortertListe = identOgTypeListe.sorted()
+
+        // Assert
+        assertThat(sortertListe).containsExactlyElementsOf(forventetSortertListe)
+    }
+}

--- a/src/test/resources/cucumber/oppdrag/ytelsestyper.feature
+++ b/src/test/resources/cucumber/oppdrag/ytelsestyper.feature
@@ -15,8 +15,8 @@ Egenskap: Ulike ytelsestyper på andelene
 
     Så forvent følgende utbetalingsoppdrag
       | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Ytelse             | Kode endring | Er endring | Periode id | Forrige periode id |
-      | 1            | 03.2021  | 03.2021  |             | 700   | UTVIDET_BARNETRYGD | NY           | Nei        | 0          |                    |
-      | 1            | 03.2021  | 03.2021  |             | 800   | SMÅBARNSTILLEGG    | NY           | Nei        | 1          |                    |
+      | 1            | 03.2021  | 03.2021  |             | 800   | SMÅBARNSTILLEGG    | NY           | Nei        | 0          |                    |
+      | 1            | 03.2021  | 03.2021  |             | 700   | UTVIDET_BARNETRYGD | NY           | Nei        | 1          |                    |
 
   Scenario: Revurdering endrer beløp på småbarnstillegg fra april
 
@@ -32,9 +32,9 @@ Egenskap: Ulike ytelsestyper på andelene
 
     Så forvent følgende utbetalingsoppdrag
       | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Ytelse             | Kode endring | Er endring | Periode id | Forrige periode id |
-      | 1            | 03.2021  | 05.2021  |             | 700   | UTVIDET_BARNETRYGD | NY           | Nei        | 0          |                    |
-      | 1            | 03.2021  | 05.2021  |             | 800   | SMÅBARNSTILLEGG    | NY           | Nei        | 1          |                    |
-      | 2            | 04.2021  | 05.2021  |             | 800   | SMÅBARNSTILLEGG    | ENDR         | Nei        | 2          | 1                  |
+      | 1            | 03.2021  | 05.2021  |             | 800   | SMÅBARNSTILLEGG    | NY           | Nei        | 0          |                    |
+      | 1            | 03.2021  | 05.2021  |             | 700   | UTVIDET_BARNETRYGD | NY           | Nei        | 1          |                    |
+      | 2            | 04.2021  | 05.2021  |             | 800   | SMÅBARNSTILLEGG    | ENDR         | Nei        | 2          | 0                  |
 
   Scenario: Forelder og barn har flere stønadstyper som alle blir egne kjeder. Øker hvert beløp med 100kr i revurderingen for å verifisere at det fortsatt blir 4 ulike kjeder
 
@@ -54,12 +54,12 @@ Egenskap: Ulike ytelsestyper på andelene
 
     Så forvent følgende utbetalingsoppdrag
       | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Ytelse             | Kode endring | Er endring | Periode id | Forrige periode id |
-      | 1            | 03.2021  | 03.2021  |             | 100   | UTVIDET_BARNETRYGD | NY           | Nei        | 0          |                    |
+      | 1            | 03.2021  | 03.2021  |             | 300   | ORDINÆR_BARNETRYGD | NY           | Nei        | 0          |                    |
       | 1            | 03.2021  | 03.2021  |             | 200   | SMÅBARNSTILLEGG    | NY           | Nei        | 1          |                    |
-      | 1            | 03.2021  | 03.2021  |             | 300   | ORDINÆR_BARNETRYGD | NY           | Nei        | 2          |                    |
+      | 1            | 03.2021  | 03.2021  |             | 100   | UTVIDET_BARNETRYGD | NY           | Nei        | 2          |                    |
       | 1            | 03.2021  | 03.2021  |             | 400   | UTVIDET_BARNETRYGD | NY           | Nei        | 3          |                    |
 
-      | 2            | 03.2021  | 03.2021  |             | 200   | UTVIDET_BARNETRYGD | ENDR         | Nei        | 4          | 0                  |
+      | 2            | 03.2021  | 03.2021  |             | 400   | ORDINÆR_BARNETRYGD | ENDR         | Nei        | 4          | 0                  |
       | 2            | 03.2021  | 03.2021  |             | 300   | SMÅBARNSTILLEGG    | ENDR         | Nei        | 5          | 1                  |
-      | 2            | 03.2021  | 03.2021  |             | 400   | ORDINÆR_BARNETRYGD | ENDR         | Nei        | 6          | 2                  |
+      | 2            | 03.2021  | 03.2021  |             | 200   | UTVIDET_BARNETRYGD | ENDR         | Nei        | 6          | 2                  |
       | 2            | 03.2021  | 03.2021  |             | 500   | UTVIDET_BARNETRYGD | ENDR         | Nei        | 7          | 3                  |


### PR DESCRIPTION
Sørger for at vi sorterer `IdentOgType` etter `type.klassifisering`+`ident` før vi genererer nye kjedeelementer for å være sikre på at kjedeelementene i en behandling alltid genereres likt. Altså at vi alltid får det samme resultatet om vi lager utbetalingsoppdrag for den samme behandlingen flere ganger.

Bakgrunnen for endringen er en prodfeil i ba-sak hvor utbetalingsoppdraget Oppdrag har hos seg har andre periode-ider enn utbetalingsoppdraget vi har lagret hos oss. https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24177