### PR TITLE
Fix: Sørger for at vi oppdaterer kildeBehandlingId i bestående andeler som er avkortet

### DIFF
--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/Utbetalingsgenerator.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/Utbetalingsgenerator.kt
@@ -183,23 +183,26 @@ class Utbetalingsgenerator {
         nyeKjeder: List<ResultatForKjede>,
     ): List<AndelMedPeriodeId> =
         nyeKjeder.flatMap { nyKjede ->
-            nyKjede.beståendeAndeler.map { beståendeAndel ->
-                AndelMedPeriodeId(
-                    andel = beståendeAndel,
-                    nyKildeBehandlingId =
-                        bestemKildeBehandlingIdForBeståendeAndel(
-                            beståendeAndel = beståendeAndel,
-                            opphørsandel = nyKjede.opphørsandel?.first,
-                            inneværendeBehandlingId = behandlingsinformasjon.behandlingId,
-                        ),
-                )
-            } +
+            val beståendeAndelerMedPeriodeId =
+                nyKjede.beståendeAndeler.map { beståendeAndel ->
+                    AndelMedPeriodeId(
+                        andel = beståendeAndel,
+                        nyKildeBehandlingId =
+                            bestemKildeBehandlingIdForBeståendeAndel(
+                                beståendeAndel = beståendeAndel,
+                                opphørsandel = nyKjede.opphørsandel?.first,
+                                inneværendeBehandlingId = behandlingsinformasjon.behandlingId,
+                            ),
+                    )
+                }
+            val nyeAndelerMedPeriodeId =
                 nyKjede.nyeAndeler.map { nyAndel ->
                     AndelMedPeriodeId(
                         andel = nyAndel,
                         nyKildeBehandlingId = behandlingsinformasjon.behandlingId,
                     )
                 }
+            beståendeAndelerMedPeriodeId + nyeAndelerMedPeriodeId
         }
 
     private fun bestemKildeBehandlingIdForBeståendeAndel(

--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/Utbetalingsgenerator.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/Utbetalingsgenerator.kt
@@ -13,6 +13,7 @@ import no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag
 import no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsoppdrag.KodeEndring
 import no.nav.familie.felles.utbetalingsgenerator.domain.Utbetalingsperiode
 import no.nav.familie.felles.utbetalingsgenerator.domain.groupByIdentOgType
+import no.nav.familie.felles.utbetalingsgenerator.domain.representererSammePeriodeSom
 import no.nav.familie.felles.utbetalingsgenerator.domain.uten0beløp
 import org.slf4j.LoggerFactory
 import java.time.YearMonth
@@ -182,11 +183,38 @@ class Utbetalingsgenerator {
         nyeKjeder: List<ResultatForKjede>,
     ): List<AndelMedPeriodeId> =
         nyeKjeder.flatMap { nyKjede ->
-            nyKjede.beståendeAndeler.map { AndelMedPeriodeId(it) } +
-                nyKjede.nyeAndeler.map {
-                    AndelMedPeriodeId(it, behandlingsinformasjon.behandlingId)
+            nyKjede.beståendeAndeler.map { beståendeAndel ->
+                AndelMedPeriodeId(
+                    andel = beståendeAndel,
+                    nyKildeBehandlingId =
+                        bestemKildeBehandlingIdForBeståendeAndel(
+                            beståendeAndel = beståendeAndel,
+                            opphørsandel = nyKjede.opphørsandel?.first,
+                            inneværendeBehandlingId = behandlingsinformasjon.behandlingId,
+                        ),
+                )
+            } +
+                nyKjede.nyeAndeler.map { nyAndel ->
+                    AndelMedPeriodeId(
+                        andel = nyAndel,
+                        nyKildeBehandlingId = behandlingsinformasjon.behandlingId,
+                    )
                 }
         }
+
+    private fun bestemKildeBehandlingIdForBeståendeAndel(
+        beståendeAndel: AndelData,
+        opphørsandel: AndelData?,
+        inneværendeBehandlingId: String,
+    ): String? {
+        val beståendeAndelErOpphørsandel = opphørsandel?.representererSammePeriodeSom(beståendeAndel) ?: false
+
+        return if (beståendeAndelErOpphørsandel) {
+            inneværendeBehandlingId
+        } else {
+            null
+        }
+    }
 
     // Hos økonomi skiller man på endring på oppdragsnivå 110 og på linjenivå 150 (periodenivå).
     // Da de har opplevd å motta

--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/AndelData.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/AndelData.kt
@@ -19,6 +19,9 @@ data class AndelData(
     val utbetalingsgrad: Int? = null,
 )
 
+fun AndelData.representererSammePeriodeSom(andelData: AndelData): Boolean =
+    this.periodeId == andelData.periodeId && this.forrigePeriodeId == andelData.forrigePeriodeId && this.fom == andelData.fom
+
 data class AndelDataLongId(
     val id: Long,
     val fom: YearMonth,

--- a/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/BeregnetUtbetalingsoppdrag.kt
+++ b/src/main/kotlin/no/nav/familie/felles/utbetalingsgenerator/domain/BeregnetUtbetalingsoppdrag.kt
@@ -19,13 +19,13 @@ data class AndelMedPeriodeId(
     val forrigePeriodeId: Long?,
     val kildeBehandlingId: String,
 ) {
-    constructor(andel: AndelData, nyttKildeBehandlingId: String? = null) :
+    constructor(andel: AndelData, nyKildeBehandlingId: String? = null) :
         this(
             id = andel.id,
             periodeId = andel.periodeId ?: error("Mangler offset på andel=${andel.id}"),
             forrigePeriodeId = andel.forrigePeriodeId,
             kildeBehandlingId =
-                nyttKildeBehandlingId ?: andel.kildeBehandlingId
+                nyKildeBehandlingId ?: andel.kildeBehandlingId
                     ?: error("Mangler kildebehandlingId på andel=${andel.id}"),
         )
 

--- a/src/test/resources/cucumber/oppdrag/flerePersoner.feature
+++ b/src/test/resources/cucumber/oppdrag/flerePersoner.feature
@@ -65,7 +65,7 @@ Egenskap: Vedtak med flere identer
       | 1            | 1  | 1          |                    | 1               |
 
       | 2            | 2  | 0          |                    | 1               |
-      | 2            | 3  | 1          |                    | 1               |
+      | 2            | 3  | 1          |                    | 2               |
 
   Scenario: Opphører ene personen, og forlenger den tredje
 

--- a/src/test/resources/cucumber/oppdrag/opphoer.feature
+++ b/src/test/resources/cucumber/oppdrag/opphoer.feature
@@ -14,9 +14,13 @@ Egenskap: Opphør
     Når beregner utbetalingsoppdrag
 
     Så forvent følgende utbetalingsoppdrag
-      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
-      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
-      | 2            | 03.2021  | 03.2021  | 03.2021     | 700   | ENDR         | Ja         | 0          |                    |
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    | 1               |
+      | 2            | 03.2021  | 03.2021  | 03.2021     | 700   | ENDR         | Ja         | 0          |                    | 2               |
+
+    Så forvent følgende andeler med periodeId
+      | BehandlingId | Id | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 0  | 0          |                    | 1               |
 
   Scenario: Iverksetter på nytt etter opphør
 
@@ -29,10 +33,16 @@ Egenskap: Opphør
     Når beregner utbetalingsoppdrag
 
     Så forvent følgende utbetalingsoppdrag
-      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
-      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
-      | 2            | 03.2021  | 03.2021  | 03.2021     | 700   | ENDR         | Ja         | 0          |                    |
-      | 3            | 03.2021  | 03.2021  |             | 700   | ENDR         | Nei        | 1          | 0                  |
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    | 1               |
+      | 2            | 03.2021  | 03.2021  | 03.2021     | 700   | ENDR         | Ja         | 0          |                    | 2               |
+      | 3            | 03.2021  | 03.2021  |             | 700   | ENDR         | Nei        | 1          | 0                  | 3               |
+
+    Så forvent følgende andeler med periodeId
+      | BehandlingId | Id | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 0  | 0          |                    | 1               |
+
+      | 3            | 1  | 1          | 0                  | 3               |
 
   Scenario: Opphør en av 2 perioder
 
@@ -45,10 +55,17 @@ Egenskap: Opphør
     Når beregner utbetalingsoppdrag
 
     Så forvent følgende utbetalingsoppdrag
-      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
-      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
-      | 1            | 04.2021  | 04.2021  |             | 800   | NY           | Nei        | 1          | 0                  |
-      | 2            | 04.2021  | 04.2021  | 04.2021     | 800   | ENDR         | Ja         | 1          | 0                  |
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    | 1               |
+      | 1            | 04.2021  | 04.2021  |             | 800   | NY           | Nei        | 1          | 0                  | 1               |
+      | 2            | 04.2021  | 04.2021  | 04.2021     | 800   | ENDR         | Ja         | 1          | 0                  | 2               |
+
+    Så forvent følgende andeler med periodeId
+      | BehandlingId | Id | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 0  | 0          |                    | 1               |
+      | 1            | 1  | 1          | 0                  | 1               |
+
+      | 2            | 2  | 0          |                    | 1               |
 
 
   Scenario: Opphører en lang periode
@@ -61,9 +78,15 @@ Egenskap: Opphør
     Når beregner utbetalingsoppdrag
 
     Så forvent følgende utbetalingsoppdrag
-      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
-      | 1            | 03.2021  | 06.2021  |             | 700   | NY           | Nei        | 0          |                    |
-      | 2            | 03.2021  | 06.2021  | 05.2021     | 700   | ENDR         | Ja         | 0          |                    |
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 03.2021  | 06.2021  |             | 700   | NY           | Nei        | 0          |                    | 1               |
+      | 2            | 03.2021  | 06.2021  | 05.2021     | 700   | ENDR         | Ja         | 0          |                    | 2               |
+
+    Så forvent følgende andeler med periodeId
+      | BehandlingId | Id | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 0  | 0          |                    | 1               |
+
+      | 2            | 1  | 0          |                    | 2               |
 
   Scenario: Opphør en tidligere periode då vi kun har med den andre av 2 perioder
 
@@ -77,11 +100,19 @@ Egenskap: Opphør
 
     Så forvent følgende utbetalingsoppdrag
       | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id | Kildebehandling |
-      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |                 |
-      | 1            | 04.2021  | 04.2021  |             | 700   | NY           | Nei        | 1          | 0                  |                 |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    | 1               |
+      | 1            | 04.2021  | 04.2021  |             | 700   | NY           | Nei        | 1          | 0                  | 1               |
 
-      | 2            | 04.2021  | 04.2021  | 03.2021     | 700   | ENDR         | Ja         | 1          | 0                  |                 |
-      | 2            | 04.2021  | 04.2021  |             | 700   | ENDR         | Nei        | 2          | 1                  |                 |
+      | 2            | 04.2021  | 04.2021  | 03.2021     | 700   | ENDR         | Ja         | 1          | 0                  | 2               |
+      | 2            | 04.2021  | 04.2021  |             | 700   | ENDR         | Nei        | 2          | 1                  | 2               |
+
+
+    Så forvent følgende andeler med periodeId
+      | BehandlingId | Id | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 0  | 0          |                    | 1               |
+      | 1            | 1  | 1          | 0                  | 1               |
+
+      | 2            | 2  | 2          | 1                  | 2               |
 
   Scenario: Endrer en tidligere periode til 0-utbetaling
 
@@ -95,12 +126,19 @@ Egenskap: Opphør
     Når beregner utbetalingsoppdrag
 
     Så forvent følgende utbetalingsoppdrag
-      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
-      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
-      | 1            | 04.2021  | 04.2021  |             | 700   | NY           | Nei        | 1          | 0                  |
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    | 1               |
+      | 1            | 04.2021  | 04.2021  |             | 700   | NY           | Nei        | 1          | 0                  | 1               |
 
-      | 2            | 04.2021  | 04.2021  | 03.2021     | 700   | ENDR         | Ja         | 1          | 0                  |
-      | 2            | 04.2021  | 04.2021  |             | 700   | ENDR         | Nei        | 2          | 1                  |
+      | 2            | 04.2021  | 04.2021  | 03.2021     | 700   | ENDR         | Ja         | 1          | 0                  | 2               |
+      | 2            | 04.2021  | 04.2021  |             | 700   | ENDR         | Nei        | 2          | 1                  | 2               |
+
+    Så forvent følgende andeler med periodeId
+      | BehandlingId | Id | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 0  | 0          |                    | 1               |
+      | 1            | 1  | 1          | 0                  | 1               |
+
+      | 2            | 3  | 2          | 1                  | 2               |
 
 
   Scenario: 2 opphør etter hverandre på ulike perioder
@@ -117,14 +155,25 @@ Egenskap: Opphør
     Når beregner utbetalingsoppdrag
 
     Så forvent følgende utbetalingsoppdrag
-      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
-      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
-      | 1            | 04.2021  | 04.2021  |             | 800   | NY           | Nei        | 1          | 0                  |
-      | 1            | 05.2021  | 05.2021  |             | 900   | NY           | Nei        | 2          | 1                  |
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    | 1               |
+      | 1            | 04.2021  | 04.2021  |             | 800   | NY           | Nei        | 1          | 0                  | 1               |
+      | 1            | 05.2021  | 05.2021  |             | 900   | NY           | Nei        | 2          | 1                  | 1               |
 
-      | 2            | 05.2021  | 05.2021  | 05.2021     | 900   | ENDR         | Ja         | 2          | 1                  |
+      | 2            | 05.2021  | 05.2021  | 05.2021     | 900   | ENDR         | Ja         | 2          | 1                  | 2               |
 
-      | 3            | 05.2021  | 05.2021  | 04.2021     | 900   | ENDR         | Ja         | 2          | 1                  |
+      | 3            | 05.2021  | 05.2021  | 04.2021     | 900   | ENDR         | Ja         | 2          | 1                  | 3               |
+
+    Så forvent følgende andeler med periodeId
+      | BehandlingId | Id | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 0  | 0          |                    | 1               |
+      | 1            | 1  | 1          | 0                  | 1               |
+      | 1            | 2  | 2          | 1                  | 1               |
+
+      | 2            | 3  | 0          |                    | 1               |
+      | 2            | 4  | 1          | 0                  | 1               |
+
+      | 3            | 5  | 0          |                    | 1               |
 
 
   Scenario: Opphør mellom 2 andeler
@@ -138,10 +187,18 @@ Egenskap: Opphør
     Når beregner utbetalingsoppdrag
 
     Så forvent følgende utbetalingsoppdrag
-      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
-      | 1            | 03.2021  | 08.2021  |             | 700   | NY           | Nei        | 0          |                    |
-      | 2            | 03.2021  | 08.2021  | 05.2021     | 700   | ENDR         | Ja         | 0          |                    |
-      | 2            | 07.2021  | 08.2021  |             | 700   | ENDR         | Nei        | 1          | 0                  |
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 03.2021  | 08.2021  |             | 700   | NY           | Nei        | 0          |                    | 1               |
+      | 2            | 03.2021  | 08.2021  | 05.2021     | 700   | ENDR         | Ja         | 0          |                    | 2               |
+      | 2            | 07.2021  | 08.2021  |             | 700   | ENDR         | Nei        | 1          | 0                  | 2               |
+
+    Så forvent følgende andeler med periodeId
+      | BehandlingId | Id | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 0  | 0          |                    | 1               |
+
+      | 2            | 1  | 0          |                    | 2               |
+      | 2            | 2  | 1          | 0                  | 2               |
+
 
   Scenario: Avkorter en periode, som man sen opphører. Her må opphøret ha peiling på siste andelen med riktig tom
 
@@ -156,11 +213,11 @@ Egenskap: Opphør
     Når beregner utbetalingsoppdrag
 
     Så forvent følgende utbetalingsoppdrag
-      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id |
-      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    |
-      | 1            | 04.2021  | 08.2021  |             | 700   | NY           | Nei        | 1          | 0                  |
-      | 2            | 04.2021  | 08.2021  | 06.2021     | 700   | ENDR         | Ja         | 1          | 0                  |
-      | 3            | 04.2021  | 08.2021  | 04.2021     | 700   | ENDR         | Ja         | 1          | 0                  |
+      | BehandlingId | Fra dato | Til dato | Opphørsdato | Beløp | Kode endring | Er endring | Periode id | Forrige periode id | Kildebehandling |
+      | 1            | 03.2021  | 03.2021  |             | 700   | NY           | Nei        | 0          |                    | 1               |
+      | 1            | 04.2021  | 08.2021  |             | 700   | NY           | Nei        | 1          | 0                  | 1               |
+      | 2            | 04.2021  | 08.2021  | 06.2021     | 700   | ENDR         | Ja         | 1          | 0                  | 2               |
+      | 3            | 04.2021  | 08.2021  | 04.2021     | 700   | ENDR         | Ja         | 1          | 0                  | 3               |
 
     Så forvent følgende andeler med periodeId
       | BehandlingId | Id | Periode id | Forrige periode id | Kildebehandling |
@@ -168,6 +225,6 @@ Egenskap: Opphør
       | 1            | 1  | 1          | 0                  | 1               |
 
       | 2            | 2  | 0          |                    | 1               |
-      | 2            | 3  | 1          | 0                  | 1               |
+      | 2            | 3  | 1          | 0                  | 2               |
 
       | 3            | 4  | 0          |                    | 1               |


### PR DESCRIPTION
[NAV-24387](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24387)

Ved forrige konsistensavstemming for `ba-sak` hadde vi flere avvik som gikk på at vi sendte med feil `kildeBehandlingId` for noen andeler/utbetalingsperioder. Det betyr at vi sier til Oppdrag at en andel/utbetalingsandel ble opprettet/oppdatert i en annen behandling enn det som faktisk var tilfellet. Altså er det i noen tilfeller en mismatch mellom `kildeBehandlingId` i en utbetalingsperiode i utbetalingsoppdraget sendt til Oppdrag, og det utbetalingsgeneratoren returnerer for samsvarende andel i feltet `andeler`.

Dette skjer ved opphør hvor vi avkorter en eksisterende andel/utbetalingsperiode. Andelen som da opphøres blir ikke oppdatert med behandlingsId til inneværende behandling hvor opphøret skjer, men peker fortsatt på en tidligere behandling.

Korrigerer dette her ved å sjekke om en `beståendeAndel` representerer samme utbetalingsperiode som `opphørsandel`. Gjør den det setter vi `kildeBehandlingId` til inneværende behandling sin id. Ellers lar vi `kildeBehandlingId` være uendret slik som før.

Lagt til `kildeBehandlingId` i cucumber-testene for opphør for å validere endringen.